### PR TITLE
fix: corrigiendo objeto de error en login endpoint

### DIFF
--- a/src/user-service/login.ts
+++ b/src/user-service/login.ts
@@ -24,7 +24,7 @@ module.exports.handler = async (event: any) => {
 
   if (!rowsAffectedasNumber) {
     console.warn(LOGIN_FAILED);
-    return generateJsonResponse({ LOGIN_FAILED }, 404);
+    return generateJsonResponse(LOGIN_FAILED, 404);
   }
 
   const token = jwt.sign(recordset[0], process.env.TOKEN_JWT!, {


### PR DESCRIPTION
corrigiendo el objeto de retorno en error 404 para que el front pase los test.

los test de integracion estaban fallando porque encapsule como objeto otro objeto el cual contenia el mensaje de error cuando el usuario no era encontrado, ahora funciona como al principio