### PR TITLE
fix: agregando condicion para cuando el email es vacio o null

### DIFF
--- a/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
+++ b/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
@@ -97,8 +97,13 @@ export const propertiesForLoanRequest = {
       },
       cp_cliente: { type: 'string', pattern: '^\\d{5}$' },
       correo_electronico_cliente: {
-        type: 'string',
-        pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+        anyOf: [
+          {
+            type: 'string',
+            pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+          },
+          { type: 'string', enum: ['', null], nullable: true },
+        ],
       },
       ocupacion_cliente: { type: 'string' },
       referencias_dom_cliente: { type: 'string' },
@@ -136,8 +141,13 @@ export const propertiesForLoanRequest = {
         pattern: '^\\d{10}$',
       },
       correo_electronico_aval: {
-        type: 'string',
-        pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+        anyOf: [
+          {
+            type: 'string',
+            pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
+          },
+          { type: 'string', enum: ['', null], nullable: true },
+        ],
       },
       curp_aval: {
         type: 'string',


### PR DESCRIPTION
Habia un problema al enviar los correos vacios o nulos, esto no pasaba antes porque el campo era mandatorio por lo tanto siempre tenia info, ahora que el campo ya no es mandatorio el campo puede ser string vacio o null (cuando se recupera el dato de clientes existentes) y el ajv intenta aplicar el regex al string vacio o a null causando un error y no permitiendo proceder con la peticion.

- Se agrego una condicion para que cuando se mande string vacio o null el campo de curp tanto para aval y cliente no arroje error de schema por el ajv