### PR TITLE
fix: correccion de path que provocaba error de deploy en aws

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -100,7 +100,7 @@ functions:
     handler: ./src/customerFiles/getFile.handler
     events:
       - httpApi:
-          path: /v1/file/
+          path: /v1/file
           method: post
           authorizer:
             name: customAuthorizer


### PR DESCRIPTION
## Description

El deploy daba error por ruta incompleta (aws espera que el path termine en un caracter diferente al '/')

## Related Issue(s)

NA

## Screenshots

NA
