### PR TITLE
fix: telefonos vacios

### DIFF
--- a/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
+++ b/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
@@ -18,12 +18,22 @@ export const propertiesForLoanRequest = {
       apellido_paterno_cliente: { type: 'string' },
       apellido_materno_cliente: { type: 'string' },
       telefono_fijo_cliente: {
-        type: 'string',
-        pattern: '^\\d{10}$',
+        anyOf: [
+          {
+            type: 'string',
+            pattern: '^\\d{10}$',
+          },
+          { type: 'string', enum: ['', null], nullable: true },
+        ],
       },
       telefono_movil_cliente: {
-        type: 'string',
-        pattern: '^\\d{10}$',
+        anyOf: [
+          {
+            type: 'string',
+            pattern: '^\\d{10}$',
+          },
+          { type: 'string', enum: ['', null], nullable: true },
+        ],
       },
       curp_cliente: {
         type: 'string',
@@ -133,12 +143,22 @@ export const propertiesForLoanRequest = {
       nombre_aval: { type: 'string' },
       apellido_paterno_aval: { type: 'string' },
       telefono_fijo_aval: {
-        type: 'string',
-        pattern: '^\\d{10}$',
+        anyOf: [
+          {
+            type: 'string',
+            pattern: '^\\d{10}$',
+          },
+          { type: 'string', enum: ['', null], nullable: true },
+        ],
       },
       telefono_movil_aval: {
-        type: 'string',
-        pattern: '^\\d{10}$',
+        anyOf: [
+          {
+            type: 'string',
+            pattern: '^\\d{10}$',
+          },
+          { type: 'string', enum: ['', null], nullable: true },
+        ],
       },
       correo_electronico_aval: {
         anyOf: [


### PR DESCRIPTION
## Description

habia un problema en la insercion de registros nuevos hechos manualmente cuando unos de los campos de telefono estaban vacios, lo cual causaba invalidez del body de la request, se agrego el anyof para cubrir este escenario para los distintos tipos de telefonos, clientes, avales, moviles y fijos

## Related Issue(s)

fixes JonathanRangelB/yoox-web-app#59 

## Screenshots

ANTES:
![image](https://github.com/user-attachments/assets/a1041eeb-b69f-4019-bc97-f4ba69f01a8a)

DESPUES: 
![image](https://github.com/user-attachments/assets/0b113461-8171-446f-9f9e-487d54086918)


