### PR TITLE
fix: respuestas de endpoints

### DIFF
--- a/src/customerFiles/getFile.ts
+++ b/src/customerFiles/getFile.ts
@@ -32,9 +32,10 @@ module.exports.handler = async (event: APIGatewayEvent) => {
   const { filename, path } = data;
 
   const bucketName = process.env.BUCKET_NAME || 'documentos-clientes-yoox';
+  const upperCasePath = path.toUpperCase();
   const params: GetObjectRequest = {
     Bucket: bucketName,
-    Key: path + filename,
+    Key: upperCasePath + filename,
     ResponseContentDisposition: `attachment; filename="${filename}"`,
   };
 

--- a/src/customerFiles/getFile.ts
+++ b/src/customerFiles/getFile.ts
@@ -40,8 +40,8 @@ module.exports.handler = async (event: APIGatewayEvent) => {
 
   try {
     const command = new GetObjectCommand(params);
-    const signedUrl = await getSignedUrl(client, command, { expiresIn: 10 });
-    return generateJsonResponse({ signedUrl }, StatusCodes.OK);
+    const signedUrl = await getSignedUrl(client, command, { expiresIn: 60 });
+    return generateJsonResponse(signedUrl, StatusCodes.OK);
   } catch (error) {
     console.log(error);
     if (error instanceof Error)

--- a/src/customerFiles/listFiles.ts
+++ b/src/customerFiles/listFiles.ts
@@ -32,7 +32,7 @@ module.exports.handler = async (event: APIGatewayEvent) => {
     const data = await client.send(command);
     const files = data.Contents?.map((item) => item.Key) || [];
 
-    return generateJsonResponse({ files }, StatusCodes.OK);
+    return generateJsonResponse(files, StatusCodes.OK);
   } catch (error) {
     console.error(error);
     if (error instanceof Error)

--- a/src/customerFiles/uploadFiles.ts
+++ b/src/customerFiles/uploadFiles.ts
@@ -34,17 +34,18 @@ module.exports.handler = async (event: APIGatewayEvent) => {
 
   try {
     const uploadUrls = await Promise.all(
-      filenames.map(async (filename: string) => {
+      filenames.map(async (fullFileName: string) => {
+        const [path, filename] = fullFileName.split('/');
         const params: PutObjectRequest = {
           Bucket: bucketName,
-          Key: filename, // Archivo que se subirá con su ruta completa. Ej: documentos/imagen/{filename}
+          Key: `${path.toUpperCase()}/${filename}`, // Archivo que se subirá con su ruta completa. Ej: documentos/imagen/{filename}
           ContentType: 'application/octet-stream', // Tipo de contenido generico binario, osea cualquier tipo de archivo
         };
         const command = new PutObjectCommand(params);
         const signedUrl = await getSignedUrl(client, command, {
           expiresIn: 30,
         });
-        return { filename, signedUrl };
+        return { filename: fullFileName, signedUrl };
       })
     );
 


### PR DESCRIPTION
## Description

1. Tenia mal puestas las respuestas de 2 endpoints, las simplifique para que fuera mas sencillo consumir dichas respuestas.
2. También se cambió el tiempo de expiración a 60 segundos para darle tiempo al usuario de seleccionar donde descargar el archivo en su dispositivo

## Related Issue(s)

NA

## Screenshots

NA
