### PR TITLE
chore: agregando conf de conexion a S3

### DIFF
--- a/src/customerFiles/uploadFiles.ts
+++ b/src/customerFiles/uploadFiles.ts
@@ -11,7 +11,14 @@ import { generateJsonResponse } from '../helpers/generateJsonResponse';
 import { StatusCodes } from '../helpers/statusCodes';
 import { FileNamesSchema } from './schemas/filenames.schema';
 
-const client = new S3Client();
+const client = new S3Client({
+  region: process.env.AWS_REGION,
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+  },
+});
+
 const ajv = new Ajv({ allErrors: true });
 
 module.exports.handler = async (event: APIGatewayEvent) => {


### PR DESCRIPTION
## Description

Antes se estaban cargando las credenciales desde el CLI, pero no deberia de ser asi sino que se deben proporcionar como variables de entorno para que cualquiera que levante el servicio de backend tenga acceso a los datos.

## Related Issue(s)

N/A

## Screenshots

N/A
