### PR TITLE
feat: endpoint status solicitud

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -159,6 +159,13 @@ functions:
           authorizer:
             name: customAuthorizer
 
+  customerLoanStatus:
+    handler: ./src/customerLoanStatus/customerLoanStatus.handler
+    events:
+      - httpApi:
+          method: get
+          path: /v1/customer-loan-status
+
   customAuthorizer:
     handler: ./src/authorizer/auth.handler
 

--- a/src/customerLoanStatus/customerLoanStatus.ts
+++ b/src/customerLoanStatus/customerLoanStatus.ts
@@ -1,0 +1,46 @@
+import { APIGatewayEvent } from 'aws-lambda';
+
+import { DbConnector } from '../helpers/dbConnector';
+import { StatusCodes } from '../helpers/statusCodes';
+import { generateGetJsonResponse } from '../helpers/generateGetJsonResponse';
+import { CustomerLoanStatus } from './types/customerLoanStatus.types';
+import { generateJsonResponse } from '../helpers/generateJsonResponse';
+
+module.exports.handler = async (event: APIGatewayEvent) => {
+  try {
+    const loanid = event.queryStringParameters?.loanid;
+    const apellido_paterno_cliente = event.queryStringParameters?.apellido;
+    if (!loanid || !apellido_paterno_cliente)
+      throw new Error('Parametros incompletos');
+    const pool = await DbConnector.getInstance().connection;
+    const query = `
+    SELECT
+        l.request_number,
+        l.loan_request_status,
+        u.nombre AS nombre_agente,
+        l.nombre_cliente,
+        l.apellido_paterno_cliente,
+        l.apellido_materno_cliente,
+        l.nombre_aval,
+        l.apellido_paterno_aval,
+        l.apellido_materno_aval,
+        l.cantidad_prestada,
+        l.fecha_inicial
+    FROM
+        LOAN_REQUEST l
+    JOIN
+        usuarios u ON l.id_agente = u.id
+    WHERE
+        l.request_number = '${loanid}' AND
+        l.apellido_paterno_cliente = '${apellido_paterno_cliente}'`;
+    const result = await pool.query<CustomerLoanStatus>(query);
+    if (result.recordset.length == 0)
+      throw new Error('No se encontraron registros');
+
+    return generateGetJsonResponse(result.recordset[0], StatusCodes.OK);
+  } catch (err) {
+    if (err instanceof Error) {
+      return generateJsonResponse(err.message, StatusCodes.BAD_REQUEST);
+    }
+  }
+};

--- a/src/customerLoanStatus/types/customerLoanStatus.types.ts
+++ b/src/customerLoanStatus/types/customerLoanStatus.types.ts
@@ -1,0 +1,13 @@
+export interface CustomerLoanStatus {
+  request_number: string;
+  loan_request_status: string;
+  nombre_agente: string;
+  nombre_cliente: string;
+  apellido_paterno_cliente: string;
+  apellido_materno_cliente: string;
+  nombre_aval: string;
+  apellido_paterno_aval: string;
+  apellido_materno_aval: string;
+  cantidad_prestada: number;
+  fecha_inicial: Date;
+}

--- a/src/helpers/generateGetJsonResponse.ts
+++ b/src/helpers/generateGetJsonResponse.ts
@@ -4,16 +4,14 @@ export const generateGetJsonResponse = (
   bodyData: any,
   statusCode: StatusCodes
 ) => {
-  const sixHoursInSeconds = 6 * 60 * 60;
-  const expires = new Date(
-    new Date().getTime() + sixHoursInSeconds * 1000
-  ).toUTCString();
+  const oneMinuteInSeconds = 60;
+  const expires = new Date(new Date().getTime() + oneMinuteInSeconds * 1000);
 
   return {
     statusCode,
     headers: {
       'Content-Type': 'application/json',
-      'Cache-Control': `public, max-age=${sixHoursInSeconds}`, // Controla la duración del caché
+      'Cache-Control': `public, must-revalidate, max-age=${oneMinuteInSeconds}`, // Controla la duración del caché
       Expires: expires, // Fecha exacta de expiración
     },
     body: JSON.stringify(bodyData),


### PR DESCRIPTION
## Description

- Nuevo endpoint para que los clientes lo usen para poder saber el status de su solicitud cuando ellos lo deseen.
- Se redujo el tiempo de cache a solo 1 minuto, antes estaba a 6 horas lo cual era exesivo para la cache.

## Related Issue(s)

N/A

## Screenshots

N/A