### PR TITLE
Arreglo en query de busqueda de telefonos aval/cliente

### DIFF
--- a/src/validators/utils/querySearchData.ts
+++ b/src/validators/utils/querySearchData.ts
@@ -30,8 +30,8 @@ export function searchTelefonoQuery(
 
   selectStatement += `
                           ${table}
-                          where telefono_fijo in (${listInCondition})
-                                or telefono_movil in (${listInCondition})  `;
+                          where (telefono_fijo in (${listInCondition})
+                                or telefono_movil in (${listInCondition}))  `;
 
   return selectStatement;
 }


### PR DESCRIPTION
## Description

Se agregan paréntesis para indicar al query que las comparaciones de OR deben comportarse como un solo bloque.

## Related Issue(s)
Al proporcionar un número de teléfono de aval/cliente y un id de aval/cliente, el query compara sólo un lado de la condicional OR e ignora el resto debido a que no se le indica al query la jerarquía por medio de paréntesis, cuando las comparaciones de ambos lados de OR deberían comportarse como una sola.

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
