### PR TITLE
New token system

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -42,6 +42,13 @@ functions:
           path: /v1/tokenValidation
           method: get
 
+  tokenRefresh:
+    handler: ./src/authorizer/tokenRefresh.handler
+    events:
+      - httpApi:
+          path: /v1/tokenRefresh
+          method: post
+
   payment:
     handler: ./src/payments/payment.handler
     events:

--- a/src/authorizer/auth.interface.ts
+++ b/src/authorizer/auth.interface.ts
@@ -1,5 +1,14 @@
 export interface TokenPayload {
-  user: any;
+  ID: number;
+  NOMBRE: 'JOSE HERIBERTO SANCHEZ LARIOS';
+  ROL: string;
+  ACTIVO: boolean;
+  ID_GRUPO: number;
+  ID_ROL: number;
   iat: number;
   exp: number;
+}
+
+export interface RefreshRequestBody {
+  token: string;
 }

--- a/src/authorizer/auth.interface.ts
+++ b/src/authorizer/auth.interface.ts
@@ -1,0 +1,5 @@
+export interface TokenPayload {
+  user: any;
+  iat: number;
+  exp: number;
+}

--- a/src/authorizer/tokenRefresh.ts
+++ b/src/authorizer/tokenRefresh.ts
@@ -1,0 +1,141 @@
+import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
+import * as jwt from 'jsonwebtoken';
+import { StatusCodes } from '../helpers/statusCodes';
+
+interface TokenPayload {
+  ID: number;
+  NOMBRE: 'JOSE HERIBERTO SANCHEZ LARIOS';
+  ROL: string;
+  ACTIVO: boolean;
+  ID_GRUPO: number;
+  ID_ROL: number;
+  iat: number;
+  exp: number;
+}
+
+interface RefreshRequestBody {
+  token: string;
+}
+
+export const handler = async (
+  event: APIGatewayEvent
+): Promise<APIGatewayProxyResult> => {
+  // Headers CORS
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+    'Access-Control-Allow-Methods': 'POST,OPTIONS',
+  };
+
+  try {
+    // Manejar preflight CORS
+    if (event.httpMethod === 'OPTIONS') {
+      return {
+        statusCode: StatusCodes.OK,
+        headers,
+        body: '',
+      };
+    }
+
+    // Validar que hay body
+    if (!event.body) {
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        headers,
+        body: JSON.stringify({ error: 'Request body is required' }),
+      };
+    }
+
+    // Parsear body
+    const body: RefreshRequestBody = JSON.parse(event.body);
+
+    if (!body.token) {
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        headers,
+        body: JSON.stringify({ error: 'Token is required' }),
+      };
+    }
+
+    // Obtener el JWT secret del environment
+    const JWT_SECRET = process.env.TOKEN_JWT;
+    if (!JWT_SECRET) {
+      throw new Error('JWT_SECRET not configured');
+    }
+
+    // Decodificar el token SIN verificar expiración
+    // Esto permite renovar tokens que están cerca de expirar o recién expirados
+    const decodedToken = jwt.decode(body.token) as TokenPayload;
+
+    if (!decodedToken) {
+      return {
+        statusCode: StatusCodes.UNAUTHORIZED,
+        headers,
+        body: JSON.stringify({ error: 'Invalid token format' }),
+      };
+    }
+
+    // Verificar que el token no sea demasiado viejo (opcional)
+    // Por ejemplo, no permitir renovar tokens de más de 1 hora de expirados
+    const now = Math.floor(Date.now() / 1000);
+    const maxRefreshWindow = 60 * 60; // 1 hora en segundos
+
+    if (now - decodedToken.exp > maxRefreshWindow) {
+      return {
+        statusCode: StatusCodes.UNAUTHORIZED,
+        headers,
+        body: JSON.stringify({
+          error: 'Token expired beyond refresh window',
+        }),
+      };
+    }
+
+    // Verificar la firma del token original (importante para seguridad)
+    try {
+      jwt.verify(body.token, JWT_SECRET, { ignoreExpiration: true });
+    } catch (error) {
+      console.error('Token verification failed:', error);
+      return {
+        statusCode: 401,
+        headers,
+        body: JSON.stringify({ error: 'Invalid token signature' }),
+      };
+    }
+
+    // TODO: Verificar que el usuario no ha sido deshabilitado
+
+    // Generar nuevo token con nueva expiración (30 minutos)
+    const newTokenPayload: TokenPayload = {
+      ID: decodedToken.ID,
+      NOMBRE: decodedToken.NOMBRE,
+      ROL: decodedToken.ROL,
+      ACTIVO: decodedToken.ACTIVO,
+      ID_GRUPO: decodedToken.ID_GRUPO,
+      ID_ROL: decodedToken.ID_ROL,
+      iat: now,
+      exp: now + 30 * 60, // 30 minutos desde ahora
+    };
+
+    const newToken = jwt.sign(newTokenPayload, JWT_SECRET);
+
+    return {
+      statusCode: StatusCodes.OK,
+      headers,
+      body: JSON.stringify({
+        token: newToken,
+        expiresIn: 30 * 60, // segundos hasta expiración
+      }),
+    };
+  } catch (error) {
+    console.error('Error in refresh token:', { error });
+
+    return {
+      statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+      headers,
+      body: JSON.stringify({
+        error: 'Internal server error',
+      }),
+    };
+  }
+};

--- a/src/authorizer/tokenValidation.ts
+++ b/src/authorizer/tokenValidation.ts
@@ -6,6 +6,7 @@ import {
 } from 'jsonwebtoken';
 
 import { generateJsonResponse } from '../helpers/generateJsonResponse';
+import { StatusCodes } from '../helpers/statusCodes';
 
 module.exports.handler = async (event: any) => {
   const { headers } = event;
@@ -13,17 +14,29 @@ module.exports.handler = async (event: any) => {
 
   try {
     jwt.verify(authToken, process.env.TOKEN_JWT!);
-    return generateJsonResponse({ isValid: true }, 200);
+    return generateJsonResponse({ isValid: true }, StatusCodes.OK);
   } catch (err) {
     if (err instanceof JsonWebTokenError) {
-      return generateJsonResponse({ isValid: false, error: err }, 401);
+      return generateJsonResponse(
+        { isValid: false, error: err },
+        StatusCodes.UNAUTHORIZED
+      );
     }
     if (err instanceof TokenExpiredError) {
-      return generateJsonResponse({ isValid: false, error: err }, 400);
+      return generateJsonResponse(
+        { isValid: false, error: err },
+        StatusCodes.BAD_REQUEST
+      );
     }
     if (err instanceof NotBeforeError) {
-      return generateJsonResponse({ isValid: false, error: err }, 400);
+      return generateJsonResponse(
+        { isValid: false, error: err },
+        StatusCodes.BAD_REQUEST
+      );
     }
-    return generateJsonResponse({ isValid: false, error: err }, 500);
+    return generateJsonResponse(
+      { isValid: false, error: err },
+      StatusCodes.INTERNAL_SERVER_ERROR
+    );
   }
 };

--- a/src/user-service/login.ts
+++ b/src/user-service/login.ts
@@ -6,7 +6,6 @@ import { validateCredentials } from './validateCredentials';
 import { userSchema } from './schemas/userSchema';
 import { StatusCodes } from '../helpers/statusCodes';
 import { validatePayload } from '../helpers/utils';
-import { TokenPayload } from '../authorizer/auth.interface';
 
 const LOGIN_FAILED = { message: 'Login failed, verify your credentials' };
 

--- a/src/user-service/login.ts
+++ b/src/user-service/login.ts
@@ -6,6 +6,7 @@ import { validateCredentials } from './validateCredentials';
 import { userSchema } from './schemas/userSchema';
 import { StatusCodes } from '../helpers/statusCodes';
 import { validatePayload } from '../helpers/utils';
+import { TokenPayload } from '../authorizer/auth.interface';
 
 const LOGIN_FAILED = { message: 'Login failed, verify your credentials' };
 
@@ -39,8 +40,7 @@ module.exports.handler = async (event: any) => {
 
     return generateJsonResponse(
       {
-        user: recordset[0],
-        Autorization: `Bearer ${token}`,
+        token: `Bearer ${token}`,
       },
       StatusCodes.OK
     );


### PR DESCRIPTION
## Description

Nuevo endpoint para refrescar tokens.

## Related Issue(s)

- Resuelve el problema de tener que estar iniciando sesion cada 30 minutos (aun falta implementar la funcionalidad en la web).
- La web estara mandando revalidar los tokens cada ~10 minutos en el background, asi evitando friccion con el usuario con algun mensaje de confirmacion, como las aplicaciones bancarias. cuando el usuario deje de usar la app mas de 30 minutos, el refresh token no se generara dado a que solo aceptara tokens que sigan siendo validos.
- El nuevo endpoint valida que el usuario siga activo, asi evitando el escenario de que alguien intente mantener sesion activa indefinidamente si se le coloca como inactivo en la BD
- Se hicieron cambios en postman para el login y el nuevo "AUTH/V1/tokenRefresh", no usar lo de esta branch de momento para la web porque la web no esta aun adecuada para esta funcionalidad, usar un commit antes de este para que siga funcionando todo

## Screenshots

NA
