### PR TITLE
feat: endpoint para obtener la ultima version desktop

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -200,6 +200,15 @@ functions:
           authorizer:
             name: customAuthorizer
 
+  getLatestDesktopVersion:
+    handler: ./src/general-data-requests/getLatestDesktopVersion.handler
+    events:
+      - httpApi:
+          method: get
+          path: /v1/desktop-version
+          authorizer:
+            name: customAuthorizer
+
   customAuthorizer:
     handler: ./src/authorizer/auth.handler
 

--- a/src/general-data-requests/getLatestDesktopVersion.ts
+++ b/src/general-data-requests/getLatestDesktopVersion.ts
@@ -1,0 +1,24 @@
+import { APIGatewayEvent } from 'aws-lambda';
+import { generateJsonResponse } from '../helpers/generateJsonResponse';
+import { StatusCodes } from '../helpers/statusCodes';
+import { DbConnector } from '../helpers/dbConnector';
+import { DesktopVersionData } from './types/desktopVersionData';
+import { generateGetJsonResponse } from '../helpers/generateGetJsonResponse';
+
+module.exports.handler = async (_: APIGatewayEvent) => {
+  try {
+    const con = await DbConnector.getInstance().connection;
+    const res = await con.query<DesktopVersionData>(
+      `SELECT TOP 1 * FROM SEC_VERSION sv ORDER BY sv.ID_VERSION DESC`
+    );
+    if (res.recordset.length === 0) {
+      return generateJsonResponse(
+        { error: 'Query throw no data' },
+        StatusCodes.NOT_FOUND
+      );
+    }
+    return generateGetJsonResponse(res.recordset[0], StatusCodes.OK);
+  } catch (error) {
+    return generateJsonResponse(error, StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+};

--- a/src/general-data-requests/types/desktopVersionData.ts
+++ b/src/general-data-requests/types/desktopVersionData.ts
@@ -1,0 +1,9 @@
+export interface DesktopVersionData {
+  ID_VERSION?: number;
+  FILE_NAME?: string;
+  MAJOR_VERSION?: string;
+  MINOR_VERSION?: string;
+  BUILD?: string;
+  PUBLISH_DATE?: Date;
+  PUBLISH_URL?: string;
+}


### PR DESCRIPTION
## Description

Necesitaba una manera de obtener la informacion de cual era la ultima version de la applicacion de escritorio, esto para evitar tener que hardcodear la URL del instalador directamente en la pagina, lo cual es ineficiente dado a que tendria que haber un deploy de la web cada que hubiera una nueva version desktop. con esto evitamos ese escenario porque la web obtendra la URL del ultimo registro dado de alta en la BD haciendo una peticion POST de tipo GET.

## Related Issue(s)

NA

## Screenshots

NA
