### PR TITLE
se agrega cadena WEB_LOAN_REQ para sistema origen en prestamos

### DIFF
--- a/src/general-data-requests/transactions/loan/registerNewLoan.ts
+++ b/src/general-data-requests/transactions/loan/registerNewLoan.ts
@@ -118,7 +118,7 @@ export const registerNewLoan = async (
         cantidad_semanal,
         id_cobrador,
         cantidad_semanal,
-        'SYSTEM'
+        'WEB_LOAN_REQ'
       );
     }
 


### PR DESCRIPTION

## Description

Se agrega cadena que identifica las semanas de préstamos que han sido creadas desde una solicitud de préstamo cuando es aprobada

## Related Issue(s)

## Screenshots

<img width="322" height="386" alt="image" src="https://github.com/user-attachments/assets/2112002a-1f75-46d1-8cef-f335d4ea56f3" />

