### PR TITLE
fix: id_loan_to_refinance error columna duplicada

### DIFF
--- a/src/loan-requests/loans/registerUpdateLoanRequest.ts
+++ b/src/loan-requests/loans/registerUpdateLoanRequest.ts
@@ -160,8 +160,8 @@ export const registerUpdateLoanRequest = async (
           updateQueryColumns = fullUpdateLoanReqQuery(updateLoanRequest, false);
           updateQueryColumns += ` ,MODIFIED_BY = ${id_usuario}
                                   ,MODIFIED_DATE = '${current_local_date.toISOString()}'
-                                  ,ID_LOAN_TO_REFINANCE = ${id_loan_to_refinance ? id_loan_to_refinance : `NULL`}                                 
           `;
+
           break;
 
         case Status.RECHAZADO:


### PR DESCRIPTION
## Description
Error al actualizar o mandar a revisión una solicitud, por duplicado en el campo id_loan_to_refinance

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
