### PR TITLE
feat: validacion ocupacion cliente/aval 200 caracteres máximos

### DIFF
--- a/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
+++ b/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
@@ -1,4 +1,3 @@
-import { format } from "path";
 import {
   REGEX_PHONE,
   REGEX_CURP,


### PR DESCRIPTION
## Description
Por petición de usuario, se amplia el tamaño de la cadena para campo ocupación de objetos aval/cliente de 50 a 200 caracteres. 
Validación de esquema de dicho campo.

## Related Issue(s)

#98 

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
