### PR TITLE
Cambio fecha inicial/final estimada a opcionales

### DIFF
--- a/src/general-data-requests/transactions/loan/registerNewLoan.ts
+++ b/src/general-data-requests/transactions/loan/registerNewLoan.ts
@@ -35,6 +35,15 @@ export const registerNewLoan = async (
         currentSystemDate,
         semanas_plazo
       );
+
+    const dia_semana_calculado: string = fecha_inicial
+      ? dia_semana
+      : fecha_inicial_calculada
+          .toLocaleDateString("es-ES", { weekday: "long" })
+          .normalize("NFD")
+          .replace(/\p{M}/gu, "")
+          .toUpperCase();
+
     const nextIdQuery = await procTransaction
       .request()
       .query<IndexesId>(
@@ -96,7 +105,7 @@ export const registerNewLoan = async (
       id_plazo,
       id_usuario,
       cantidad_prestada,
-      dia_semana,
+      dia_semana_calculado,
       fecha_inicial_calculada,
       fecha_final_estimada_calculada,
       fecha_final_estimada_calculada,

--- a/src/general-data-requests/transactions/loan/registerNewLoan.ts
+++ b/src/general-data-requests/transactions/loan/registerNewLoan.ts
@@ -28,21 +28,17 @@ export const registerNewLoan = async (
       semanas_plazo,
     } = loan_header;
 
-    const { fecha_inicial_calculada, fecha_final_estimada_calculada } =
-      calculateEndDate(
-        fecha_inicial,
-        fecha_final_estimada,
-        currentSystemDate,
-        semanas_plazo
-      );
-
-    const dia_semana_calculado: string = fecha_inicial
-      ? dia_semana
-      : fecha_inicial_calculada
-          .toLocaleDateString("es-ES", { weekday: "long" })
-          .normalize("NFD")
-          .replace(/\p{M}/gu, "")
-          .toUpperCase();
+    const {
+      fecha_inicial_calculada,
+      fecha_final_estimada_calculada,
+      dia_semana_calculado,
+    } = calculateEndDate(
+      fecha_inicial,
+      fecha_final_estimada,
+      currentSystemDate,
+      semanas_plazo,
+      dia_semana
+    );
 
     const nextIdQuery = await procTransaction
       .request()

--- a/src/general-data-requests/transactions/loan/registerNewLoan.ts
+++ b/src/general-data-requests/transactions/loan/registerNewLoan.ts
@@ -4,10 +4,12 @@ import { GenericBDRequest } from "../../types/genericBDRequest";
 import { IndexesId } from "../../../helpers/table-schemas";
 import { StatusCodes } from "../../../helpers/statusCodes";
 import { registerSnapshotRealInvestmentReport } from "../reporting/registerSnapshotRealInvestmentReport";
+import { calculateEndDate } from "../../../loan-requests/utils/calculateEndDate";
 
 export const registerNewLoan = async (
   loan_header: LoanHeader,
-  procTransaction: Transaction
+  procTransaction: Transaction,
+  currentSystemDate: Date
 ): Promise<GenericBDRequest> => {
   try {
     const {
@@ -26,6 +28,13 @@ export const registerNewLoan = async (
       semanas_plazo,
     } = loan_header;
 
+    const { fecha_inicial_calculada, fecha_final_estimada_calculada } =
+      calculateEndDate(
+        fecha_inicial,
+        fecha_final_estimada,
+        currentSystemDate,
+        semanas_plazo
+      );
     const nextIdQuery = await procTransaction
       .request()
       .query<IndexesId>(
@@ -88,9 +97,9 @@ export const registerNewLoan = async (
       id_usuario,
       cantidad_prestada,
       dia_semana,
-      fecha_inicial,
-      fecha_final_estimada,
-      fecha_final_estimada,
+      fecha_inicial_calculada,
+      fecha_final_estimada_calculada,
+      fecha_final_estimada_calculada,
       id_cobrador,
       cantidad_restante,
       cantidad_pagar,
@@ -102,13 +111,12 @@ export const registerNewLoan = async (
 
     //Inicia llenado del detalle del prestamo
 
-    const dateInUTC = new Date(fecha_inicial).getTime();
+    const dateInUTC = new Date(fecha_inicial_calculada).getTime();
     const cantidad_semanal = cantidad_pagar / semanas_plazo;
     const msSemanaAdicional = 7 * 24 * 60 * 60 * 1000;
 
     for (let counter = 1; counter <= semanas_plazo; counter++) {
       const fechaDePago = new Date(dateInUTC + counter * msSemanaAdicional);
-
       tableLoanDetailBD.rows.add(
         lastLoanId,
         counter,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -74,6 +74,7 @@ export const REGEX_EMAIL: string =
   "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
 export const REGEX_ZIP_CODE: string = "^\\d{5}$";
 export const REGEX_PHONE: string = "^\\d{10}$";
+export const REGEX_EMPTY_STRING: string = "^\\s*$";
 
 export const Status = {
   EN_REVISION: "EN REVISION",

--- a/src/loan-requests/loans/registerUpdateLoanRequest.ts
+++ b/src/loan-requests/loans/registerUpdateLoanRequest.ts
@@ -160,7 +160,8 @@ export const registerUpdateLoanRequest = async (
       updateQueryColumns = fullUpdateLoanReqQuery(
         updateLoanRequest,
         false,
-        poolRequest
+        poolRequest,
+        current_local_date
       );
 
       updateQueryColumns += `
@@ -185,7 +186,8 @@ export const registerUpdateLoanRequest = async (
           updateQueryColumns = fullUpdateLoanReqQuery(
             updateLoanRequest,
             false,
-            poolRequest
+            poolRequest,
+            current_local_date
           );
 
           updateQueryColumns += ` ,MODIFIED_BY = @modified_by_id_usuario
@@ -329,7 +331,8 @@ export const registerUpdateLoanRequest = async (
           } else {
             procInsertLoan = await registerNewLoan(
               encabezadoPrestamo,
-              procTransaction
+              procTransaction,
+              current_local_date
             );
           }
 
@@ -340,7 +343,8 @@ export const registerUpdateLoanRequest = async (
           updateQueryColumns = fullUpdateLoanReqQuery(
             updateLoanRequest,
             true,
-            poolRequest
+            poolRequest,
+            current_local_date
           );
 
           updateQueryColumns += `,ID_AVAL = @datosCliente_id_aval

--- a/src/loan-requests/schemas/loanNew.schema.ts
+++ b/src/loan-requests/schemas/loanNew.schema.ts
@@ -1,9 +1,13 @@
-import { propertiesForLoanRequest } from "./propertiesForLoanRequest.schema";
-import { requiredFielsForNewLoanRequest } from "./propertiesForLoanRequest.schema";
+import {
+  propertiesForLoanRequest,
+  requiredFielsForNewLoanRequest,
+  validateStartDate,
+} from "./propertiesForLoanRequest.schema";
 
 export const loanSchema = {
   type: "object",
   properties: propertiesForLoanRequest,
+  ...validateStartDate,
   required: requiredFielsForNewLoanRequest,
   additionalProperties: false,
 };

--- a/src/loan-requests/schemas/loanUpdate.schema.ts
+++ b/src/loan-requests/schemas/loanUpdate.schema.ts
@@ -1,11 +1,13 @@
 import {
   propertiesForLoanRequest,
   requiredFielsForUpdateLoanRequest,
+  validateStartDate,
 } from "./propertiesForLoanRequest.schema";
 
 export const loanSchema = {
   type: "object",
   properties: propertiesForLoanRequest,
+  ...validateStartDate,
   required: requiredFielsForUpdateLoanRequest,
   additionalProperties: false,
 };

--- a/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
+++ b/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
@@ -7,6 +7,7 @@ import {
   DiasDeSemana,
   States,
   TipoCalles,
+  REGEX_EMPTY_STRING,
 } from "../../helpers/utils";
 
 export const propertiesForLoanRequest = {
@@ -20,8 +21,29 @@ export const propertiesForLoanRequest = {
   cantidad_pagar: { type: "number" },
   id_agente: { type: "integer" },
   id_grupo_original: { type: "integer" },
-  fecha_inicial: { type: "string", format: "date-time" },
-  fecha_final_estimada: { type: "string", format: "date-time" },
+  fecha_inicial: {
+    anyOf: [
+      { type: "string", format: "date-time" },
+      {
+        type: "string",
+        enum: [null],
+        pattern: REGEX_EMPTY_STRING,
+        nullable: true,
+      },
+    ],
+  },
+  fecha_final_estimada: {
+    anyOf: [
+      { type: "string", format: "date-time" },
+      {
+        type: "string",
+        enum: [null],
+        pattern: REGEX_EMPTY_STRING,
+        nullable: true,
+      },
+    ],
+  },
+
   dia_semana: {
     type: "string",
     enum: Object.values(DiasDeSemana),
@@ -298,8 +320,6 @@ export const requiredFielsForUpdateLoanRequest = [
   "cantidad_pagar",
   "id_agente",
   "id_grupo_original",
-  "fecha_inicial",
-  "fecha_final_estimada",
   "dia_semana",
   "plazo",
   "formCliente",
@@ -313,8 +333,6 @@ export const requiredFielsForNewLoanRequest = [
   "cantidad_pagar",
   "id_agente",
   "id_grupo_original",
-  "fecha_inicial",
-  "fecha_final_estimada",
   "dia_semana",
   "plazo",
   "formCliente",
@@ -322,3 +340,18 @@ export const requiredFielsForNewLoanRequest = [
   "created_by",
   "user_role",
 ];
+
+export const validateStartDate = {
+  if: {
+    properties: {
+      fecha_inicial: { type: "string", format: "date-time" },
+    },
+    required: ["fecha_inicial"],
+  },
+  then: {
+    required: ["fecha_final_estimada"],
+    properties: {
+      fecha_final_estimada: { type: "string", format: "date-time" },
+    },
+  },
+};

--- a/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
+++ b/src/loan-requests/schemas/propertiesForLoanRequest.schema.ts
@@ -43,10 +43,16 @@ export const propertiesForLoanRequest = {
       },
     ],
   },
-
   dia_semana: {
-    type: "string",
-    enum: Object.values(DiasDeSemana),
+    anyOf: [
+      { type: "string", enum: Object.values(DiasDeSemana) },
+      {
+        type: "string",
+        enum: [null],
+        pattern: REGEX_EMPTY_STRING,
+        nullable: true,
+      },
+    ],
   },
   observaciones: {
     anyOf: [
@@ -320,7 +326,6 @@ export const requiredFielsForUpdateLoanRequest = [
   "cantidad_pagar",
   "id_agente",
   "id_grupo_original",
-  "dia_semana",
   "plazo",
   "formCliente",
   "formAval",
@@ -333,7 +338,6 @@ export const requiredFielsForNewLoanRequest = [
   "cantidad_pagar",
   "id_agente",
   "id_grupo_original",
-  "dia_semana",
   "plazo",
   "formCliente",
   "formAval",

--- a/src/loan-requests/utils/calculateEndDate.ts
+++ b/src/loan-requests/utils/calculateEndDate.ts
@@ -1,0 +1,37 @@
+export function calculateEndDate(
+  fechaInicial: Date,
+  fechaFinalEstimada: Date,
+  currentSystemDate: Date,
+  numberOfWeeks: number
+): { fecha_inicial_calculada: Date; fecha_final_estimada_calculada: Date } {
+  const fecha_inicial_tmp = fechaInicial
+    ? new Date(fechaInicial)
+    : currentSystemDate;
+  const fecha_final_estimada_tmp = fechaInicial
+    ? new Date(fechaFinalEstimada)
+    : calculateEndDateWeeks(currentSystemDate, numberOfWeeks);
+  const fecha_inicial_calculada = new Date(
+    fecha_inicial_tmp.getFullYear(),
+    fecha_inicial_tmp.getMonth(),
+    fecha_inicial_tmp.getDate()
+  );
+  const fecha_final_estimada_calculada = new Date(
+    fecha_final_estimada_tmp.getFullYear(),
+    fecha_final_estimada_tmp.getMonth(),
+    fecha_final_estimada_tmp.getDate()
+  );
+
+  return { fecha_inicial_calculada, fecha_final_estimada_calculada };
+}
+
+function calculateEndDateWeeks(
+  currentSystemDate: Date,
+  numberOfWeeks: number
+): Date {
+  const fecha_final_estimada_sistema = new Date(currentSystemDate);
+  fecha_final_estimada_sistema.setDate(
+    currentSystemDate.getDate() + numberOfWeeks * 7
+  );
+
+  return fecha_final_estimada_sistema;
+}

--- a/src/loan-requests/utils/calculateEndDate.ts
+++ b/src/loan-requests/utils/calculateEndDate.ts
@@ -2,8 +2,13 @@ export function calculateEndDate(
   fechaInicial: Date,
   fechaFinalEstimada: Date,
   currentSystemDate: Date,
-  numberOfWeeks: number
-): { fecha_inicial_calculada: Date; fecha_final_estimada_calculada: Date } {
+  numberOfWeeks: number,
+  dayOfWeek: string
+): {
+  fecha_inicial_calculada: Date;
+  fecha_final_estimada_calculada: Date;
+  dia_semana_calculado: string;
+} {
   const fecha_inicial_tmp = fechaInicial
     ? new Date(fechaInicial)
     : currentSystemDate;
@@ -20,8 +25,19 @@ export function calculateEndDate(
     fecha_final_estimada_tmp.getMonth(),
     fecha_final_estimada_tmp.getDate()
   );
+  const dia_semana_calculado: string = fechaInicial
+    ? dayOfWeek
+    : fecha_inicial_calculada
+        .toLocaleDateString("es-ES", { weekday: "long" })
+        .normalize("NFD")
+        .replace(/\p{M}/gu, "")
+        .toUpperCase();
 
-  return { fecha_inicial_calculada, fecha_final_estimada_calculada };
+  return {
+    fecha_inicial_calculada,
+    fecha_final_estimada_calculada,
+    dia_semana_calculado,
+  };
 }
 
 function calculateEndDateWeeks(

--- a/src/loan-requests/utils/generateNewLoanRequestTable.ts
+++ b/src/loan-requests/utils/generateNewLoanRequestTable.ts
@@ -84,14 +84,6 @@ export function generateNewLoanRequestTable(
   const { value: estadoAval } = efa;
   const { id, request_number, loan_request_status, created_date } =
     additionalData;
-
-  const { fecha_inicial_calculada, fecha_final_estimada_calculada } =
-    calculateEndDate(
-      fecha_inicial,
-      fecha_final_estimada,
-      created_date,
-      Number(semanas_plazo)
-    );
   const tableNewRequestLoan = new Table("LOAN_REQUEST");
 
   tableNewRequestLoan.create = false;
@@ -213,12 +205,12 @@ export function generateNewLoanRequestTable(
   tableNewRequestLoan.columns.add("CANTIDAD_PRESTADA", Float, {
     nullable: false,
   });
-  tableNewRequestLoan.columns.add("DIA_SEMANA", VarChar, { nullable: false });
+  tableNewRequestLoan.columns.add("DIA_SEMANA", VarChar, { nullable: true });
   tableNewRequestLoan.columns.add("FECHA_INICIAL", DateTime, {
-    nullable: false,
+    nullable: true,
   });
   tableNewRequestLoan.columns.add("FECHA_FINAL_ESTIMADA", DateTime, {
-    nullable: false,
+    nullable: true,
   });
   tableNewRequestLoan.columns.add("CANTIDAD_PAGAR", Float, { nullable: true });
   tableNewRequestLoan.columns.add("OBSERVACIONES", VarChar, { nullable: true });
@@ -292,9 +284,11 @@ export function generateNewLoanRequestTable(
     tasa_de_interes,
     semanas_plazo,
     cantidad_prestada,
-    dia_semana,
-    fecha_inicial_calculada,
-    fecha_final_estimada_calculada,
+
+    fecha_inicial ? dia_semana : undefined,
+    fecha_inicial || undefined,
+    fecha_inicial ? fecha_final_estimada : undefined,
+
     cantidad_pagar,
     observaciones || undefined,
     created_by,

--- a/src/loan-requests/utils/generateNewLoanRequestTable.ts
+++ b/src/loan-requests/utils/generateNewLoanRequestTable.ts
@@ -1,6 +1,5 @@
 import { DateTime, Float, Int, Table, VarChar } from "mssql";
 import { InsertNewLoanRequest } from "../types/SPInsertNewLoanRequest";
-import { calculateEndDate } from "./calculateEndDate";
 
 export function generateNewLoanRequestTable(
   newLoanRequest: InsertNewLoanRequest,

--- a/src/loan-requests/utils/generateNewLoanRequestTable.ts
+++ b/src/loan-requests/utils/generateNewLoanRequestTable.ts
@@ -1,6 +1,6 @@
 import { DateTime, Float, Int, Table, VarChar } from "mssql";
-
 import { InsertNewLoanRequest } from "../types/SPInsertNewLoanRequest";
+import { calculateEndDate } from "./calculateEndDate";
 
 export function generateNewLoanRequestTable(
   newLoanRequest: InsertNewLoanRequest,
@@ -85,6 +85,13 @@ export function generateNewLoanRequestTable(
   const { id, request_number, loan_request_status, created_date } =
     additionalData;
 
+  const { fecha_inicial_calculada, fecha_final_estimada_calculada } =
+    calculateEndDate(
+      fecha_inicial,
+      fecha_final_estimada,
+      created_date,
+      Number(semanas_plazo)
+    );
   const tableNewRequestLoan = new Table("LOAN_REQUEST");
 
   tableNewRequestLoan.create = false;
@@ -286,8 +293,8 @@ export function generateNewLoanRequestTable(
     semanas_plazo,
     cantidad_prestada,
     dia_semana,
-    fecha_inicial,
-    fecha_final_estimada,
+    fecha_inicial_calculada,
+    fecha_final_estimada_calculada,
     cantidad_pagar,
     observaciones || undefined,
     created_by,

--- a/src/loan-requests/utils/queryFullUpdateLoanReq.ts
+++ b/src/loan-requests/utils/queryFullUpdateLoanReq.ts
@@ -1,10 +1,12 @@
 import { UpdateLoanRequest } from "../types/SPInsertNewLoanRequest";
 import sql, { Request, Int, VarChar, Float, Text } from "mssql";
+import { calculateEndDate } from "./calculateEndDate";
 
 export function fullUpdateLoanReqQuery(
   updateLoanRequest: UpdateLoanRequest,
   approvedStatusFlag: boolean,
-  poolRequest: Request
+  poolRequest: Request,
+  currentSystemDate: Date
 ): string {
   let updateQueryColumns = "";
 
@@ -73,6 +75,13 @@ export function fullUpdateLoanReqQuery(
   } = datosAval;
 
   const { id: id_plazo, tasa_de_interes, semanas_plazo } = datosPlazo;
+  const { fecha_inicial_calculada, fecha_final_estimada_calculada } =
+    calculateEndDate(
+      fecha_inicial,
+      fecha_final_estimada,
+      currentSystemDate,
+      Number(semanas_plazo)
+    );
 
   updateQueryColumns = `SET 
                           LOAN_REQUEST_STATUS = @newLoanRequestStatus
@@ -167,8 +176,12 @@ export function fullUpdateLoanReqQuery(
   poolRequest.input("semanas_plazo", Int, semanas_plazo);
   poolRequest.input("cantidad_prestada", Float, cantidad_prestada);
   poolRequest.input("dia_semana", VarChar, dia_semana);
-  poolRequest.input("fecha_inicial", sql.Date, fecha_inicial);
-  poolRequest.input("fecha_final_estimada", sql.Date, fecha_final_estimada);
+  poolRequest.input("fecha_inicial", sql.Date, fecha_inicial_calculada);
+  poolRequest.input(
+    "fecha_final_estimada",
+    sql.Date,
+    fecha_final_estimada_calculada
+  );
   poolRequest.input("cantidad_pagar", Float, cantidad_pagar);
   poolRequest.input(
     "telefono_fijo_cliente",

--- a/src/loan-requests/utils/queryFullUpdateLoanReq.ts
+++ b/src/loan-requests/utils/queryFullUpdateLoanReq.ts
@@ -76,22 +76,18 @@ export function fullUpdateLoanReqQuery(
   } = datosAval;
 
   const { id: id_plazo, tasa_de_interes, semanas_plazo } = datosPlazo;
-  const { fecha_inicial_calculada, fecha_final_estimada_calculada } =
-    calculateEndDate(
-      fecha_inicial,
-      fecha_final_estimada,
-      currentSystemDate,
-      Number(semanas_plazo)
-    );
-
+  const {
+    fecha_inicial_calculada,
+    fecha_final_estimada_calculada,
+    dia_semana_calculado,
+  } = calculateEndDate(
+    fecha_inicial,
+    fecha_final_estimada,
+    currentSystemDate,
+    Number(semanas_plazo),
+    dia_semana
+  );
   const isApproved = newLoanRequestStatus === Status.APROBADO;
-  const dia_semana_calculado: string = fecha_inicial
-    ? dia_semana
-    : fecha_inicial_calculada
-        .toLocaleDateString("es-ES", { weekday: "long" })
-        .normalize("NFD")
-        .replace(/\p{M}/gu, "")
-        .toUpperCase();
 
   updateQueryColumns = `SET 
                           LOAN_REQUEST_STATUS = @newLoanRequestStatus

--- a/src/loan-requests/utils/queryFullUpdateLoanReq.ts
+++ b/src/loan-requests/utils/queryFullUpdateLoanReq.ts
@@ -1,6 +1,7 @@
 import { UpdateLoanRequest } from "../types/SPInsertNewLoanRequest";
 import sql, { Request, Int, VarChar, Float, Text } from "mssql";
 import { calculateEndDate } from "./calculateEndDate";
+import { Status } from "../../helpers/utils";
 
 export function fullUpdateLoanReqQuery(
   updateLoanRequest: UpdateLoanRequest,
@@ -82,6 +83,15 @@ export function fullUpdateLoanReqQuery(
       currentSystemDate,
       Number(semanas_plazo)
     );
+
+  const isApproved = newLoanRequestStatus === Status.APROBADO;
+  const dia_semana_calculado: string = fecha_inicial
+    ? dia_semana
+    : fecha_inicial_calculada
+        .toLocaleDateString("es-ES", { weekday: "long" })
+        .normalize("NFD")
+        .replace(/\p{M}/gu, "")
+        .toUpperCase();
 
   updateQueryColumns = `SET 
                           LOAN_REQUEST_STATUS = @newLoanRequestStatus
@@ -175,13 +185,23 @@ export function fullUpdateLoanReqQuery(
   poolRequest.input("tasa_de_interes", Int, tasa_de_interes);
   poolRequest.input("semanas_plazo", Int, semanas_plazo);
   poolRequest.input("cantidad_prestada", Float, cantidad_prestada);
-  poolRequest.input("dia_semana", VarChar, dia_semana);
-  poolRequest.input("fecha_inicial", sql.Date, fecha_inicial_calculada);
+
+  poolRequest.input(
+    "dia_semana",
+    VarChar,
+    fecha_inicial || isApproved ? dia_semana_calculado : null
+  );
+  poolRequest.input(
+    "fecha_inicial",
+    sql.Date,
+    fecha_inicial || isApproved ? fecha_inicial_calculada : null
+  );
   poolRequest.input(
     "fecha_final_estimada",
     sql.Date,
-    fecha_final_estimada_calculada
+    fecha_inicial || isApproved ? fecha_final_estimada_calculada : null
   );
+
   poolRequest.input("cantidad_pagar", Float, cantidad_pagar);
   poolRequest.input(
     "telefono_fijo_cliente",

--- a/src/loan-requests/utils/validateData.ts
+++ b/src/loan-requests/utils/validateData.ts
@@ -354,11 +354,11 @@ function validateDataResult(
   id_cliente: number,
   id_aval: number
 ): { result: boolean; message?: string } {
-  if (fecha_inicial > fecha_final_estimada) {
+  if (fecha_inicial && fecha_inicial >= fecha_final_estimada) {
     return {
       result: false,
       message:
-        "La fecha inicial no puede ser posterior a la fecha final estimada",
+        "La fecha inicial no puede ser posterior ni igual a la fecha final estimada",
     };
   }
 


### PR DESCRIPTION
## Description
Ahora la fecha inicial, fecha final estimada y día semana enviadas desde el front-end son opcionales.

Si se envía la fecha inicial desde el front-end, el back-end las usará para calcular las semanas de pagos.
Sino, el back-end usará la fecha actual del servidor de la BD para calcular las semanas de pagos, la fecha inicial, la fecha final y el día de la semana.

Nota: Si se envía la fecha inicial desde el front-end, debe enviar la fecha final estimada y el día de la semana también.

## Related Issue(s)

#97 

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
